### PR TITLE
Expo SDK 40 made a breaking change by moving AppLoading to a different package

### DIFF
--- a/src/main/com/fulcrologic/fulcro_native/expo_application_40.cljc
+++ b/src/main/com/fulcrologic/fulcro_native/expo_application_40.cljc
@@ -1,0 +1,64 @@
+(ns com.fulcrologic.fulcro-native.expo-application-40
+  (:require
+    #?@(:cljs [["expo" :as expo]
+               ["create-react-class" :as crc]])
+    [com.fulcrologic.fulcro-native.expo-assets-40 :as assets]
+    [com.fulcrologic.fulcro.application :as app]
+    [com.fulcrologic.fulcro.rendering.keyframe-render :as kr]
+    [taoensso.timbre :as log]))
+
+(defonce root-ref (atom nil))
+(defonce root-component-ref (atom nil))
+
+(defn render-root
+  "A function that can be used as the main Fulcro render for an expo app."
+  [fonts images root]
+  #?(:cljs
+     (try
+       (let [first-call? (nil? @root-ref)]
+         (reset! root-ref root)
+
+         (if-not first-call?
+           (when-let [root @root-component-ref]
+             (.forceUpdate ^js root)
+             root-component-ref)
+           (let [Root
+                 (crc
+                   #js {:getInitialState
+                        (fn []
+                          #js {:assetsLoaded false})
+                        :componentDidMount
+                        (fn []
+                          (this-as ^js this
+                            (reset! root-component-ref this)
+                            (assets/cache-assets fonts images (fn []
+                                                                (.setState this #js {:assetsLoaded true})))))
+                        :componentWillUnmount
+                        (fn []
+                          (reset! root-component-ref nil))
+                        :render
+                        (fn []
+                          (this-as this
+                            (if this.state.assetsLoaded
+                              (let [body @root-ref]
+                                (try
+                                  (if (fn? body)
+                                    (body)
+                                    body)
+                                  (catch :default e
+                                    (log/error e "Render failed"))))
+                              (assets/app-loading))
+                            ))})]
+             (expo/registerRootComponent Root))))
+       (catch :default e
+         (log/error e "Unable to mount/refresh")))))
+
+(defn fulcro-app
+  "Identical to com.fulcrologic.fulcro.application/fulcro-app, but modifies a few options
+  to ensure initial mount works properly for Native Expo apps."
+  [{:keys [cached-fonts cached-images] :as options}]
+  (app/fulcro-app
+    (merge
+      {:optimized-render! kr/render!
+       :render-root!      (partial render-root cached-fonts cached-images)}
+      options)))

--- a/src/main/com/fulcrologic/fulcro_native/expo_assets_40.cljc
+++ b/src/main/com/fulcrologic/fulcro_native/expo_assets_40.cljc
@@ -1,0 +1,48 @@
+(ns com.fulcrologic.fulcro-native.expo-assets-40
+  (:require
+    #?@(:cljs [["expo-app-loading" :default AppLoading]
+               ["expo-asset" :refer [Asset]]
+               ["expo-font" :as Font]])
+    [taoensso.timbre :as log]
+    [com.fulcrologic.fulcro-native.alpha.components :as comp]))
+
+(defn- cache-images
+  [images]
+  #?(:cljs (for [image images]
+             (when image
+               (.loadAsync Asset image)))))
+
+(defn- cache-fonts
+  [fonts]
+  #?(:cljs (for [[n f] fonts]
+             (.loadAsync Font n f))))
+
+(defn- cast-as-array
+  [coll]
+  #?(:cljs (if (or (array? coll)
+                 (not (reduceable? coll)))
+             coll
+             (into-array coll))))
+
+(defn all
+  [coll]
+  #?(:cljs (.call (aget js/Promise "all") js/Promise (cast-as-array coll))))
+
+(defn cache-assets
+  [fonts images cb]
+  (log/info "fonts:" fonts)
+  (log/info "images:" images)
+  #?(:cljs
+     (->
+       (all
+         (concat
+           (if (seq images)
+             (cache-images (clj->js images)))
+           (if (seq fonts)
+             (cache-fonts (clj->js fonts)))))
+       (.then (fn [resp]
+                (if cb (cb))))
+       (.catch (fn [err]
+                 (log/error "Loading assets failed: " (aget err "message")))))))
+
+(def app-loading #?(:cljs (comp/react-factory AppLoading) :clj :stub))


### PR DESCRIPTION
#5 

This version of expo_assets_40.cljc and expo_application_40.cljc is compatible with Expo 40.

The README should probably be updated to tell users using SDK 40+ to require a different namespace.

See https://blog.expo.io/expo-sdk-40-is-now-available-d4d73e67da33 : AppLoading has been extracted from the expo package