### PR TITLE
Remove depreciated in expo SDK-45 - AppLoading

### DIFF
--- a/src/main/com/fulcrologic/fulcro_native/expo_application_40.cljc
+++ b/src/main/com/fulcrologic/fulcro_native/expo_application_40.cljc
@@ -1,6 +1,7 @@
 (ns com.fulcrologic.fulcro-native.expo-application-40
   (:require
     #?@(:cljs [["expo" :as expo]
+               ["expo-splash-screen" :as SplashScreen]
                ["create-react-class" :as crc]])
     [com.fulcrologic.fulcro-native.expo-assets-40 :as assets]
     [com.fulcrologic.fulcro.application :as app]
@@ -26,13 +27,15 @@
                  (crc
                    #js {:getInitialState
                         (fn []
+                          (.preventAutoHideAsync SplashScreen)
                           #js {:assetsLoaded false})
                         :componentDidMount
                         (fn []
                           (this-as ^js this
                             (reset! root-component-ref this)
                             (assets/cache-assets fonts images (fn []
-                                                                (.setState this #js {:assetsLoaded true})))))
+                                                                (.setState this #js {:assetsLoaded true})
+                                                                (.hideAsync SplashScreen)))))
                         :componentWillUnmount
                         (fn []
                           (reset! root-component-ref nil))
@@ -47,8 +50,7 @@
                                     body)
                                   (catch :default e
                                     (log/error e "Render failed"))))
-                              (assets/app-loading))
-                            ))})]
+                              nil)))})]
              (expo/registerRootComponent Root))))
        (catch :default e
          (log/error e "Unable to mount/refresh")))))

--- a/src/main/com/fulcrologic/fulcro_native/expo_assets_40.cljc
+++ b/src/main/com/fulcrologic/fulcro_native/expo_assets_40.cljc
@@ -1,7 +1,6 @@
 (ns com.fulcrologic.fulcro-native.expo-assets-40
   (:require
-    #?@(:cljs [["expo-app-loading" :default AppLoading]
-               ["expo-asset" :refer [Asset]]
+    #?@(:cljs [["expo-asset" :refer [Asset]]
                ["expo-font" :as Font]])
     [taoensso.timbre :as log]
     [com.fulcrologic.fulcro-native.alpha.components :as comp]))
@@ -44,5 +43,3 @@
                 (if cb (cb))))
        (.catch (fn [err]
                  (log/error "Loading assets failed: " (aget err "message")))))))
-
-(def app-loading #?(:cljs (comp/react-factory AppLoading) :clj :stub))


### PR DESCRIPTION
In SDK-45 AppLoading was depreciated:
https://blog.expo.dev/expo-sdk-45-f4e332954a68
https://github.com/expo/expo/pull/16963

It's also specified in the documentation that it should be replaced with SplashScreen :
https://docs.expo.dev/versions/v46.0.0/sdk/app-loading/
https://github.com/expo/expo/tree/sdk-46/packages/expo-app-loading